### PR TITLE
Registering the credit table for it to be available in the sqlContext…

### DIFF
--- a/src/main/scala/example/Credit.scala
+++ b/src/main/scala/example/Credit.scala
@@ -51,7 +51,7 @@ object Credit {
     import sqlContext.implicits._
 
     val creditDF = parseRDD(sc.textFile("germancredit.csv")).map(parseCredit).toDF().cache()
-
+    creditDF.registerTempTable("credit")
     creditDF.printSchema
 
     creditDF.show


### PR DESCRIPTION
Fix for: Exception in thread "main" org.apache.spark.sql.AnalysisException: Table not found: credit;
